### PR TITLE
HYPERFLEET-1196 - chore: add sherine-k to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,37 +1,33 @@
 approvers:
-- "86254860"
 - aredenba-rh
 - ciaranRoche
 - crizzo71
 - jsell-rh
 - kuudori
+- ldornele
 - ma-hill
 - mbrudnoy
 - Mischulee
 - pnguyen44
 - rafabene
 - rh-amarin
+- sherine-k
 - tirthct
 - vkareh
-- xueli181114
-- yasun1
-- yingzhanredhat
 
 reviewers:
-- "86254860"
 - aredenba-rh
 - ciaranRoche
 - crizzo71
 - jsell-rh
 - kuudori
+- ldornele
 - ma-hill
 - mbrudnoy
 - Mischulee
 - pnguyen44
 - rafabene
 - rh-amarin
+- sherine-k
 - tirthct
 - vkareh
-- xueli181114
-- yasun1
-- yingzhanredhat


### PR DESCRIPTION
## Summary
- Add `sherine-k` to OWNERS file (approvers and reviewers)
- New team member onboarding for Prow-based code review workflows

## Related
- [HYPERFLEET-1196](https://redhat.atlassian.net/browse/HYPERFLEET-1196)

[HYPERFLEET-1196]: https://redhat.atlassian.net/browse/HYPERFLEET-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ